### PR TITLE
added instructions for E16.4.3

### DIFF
--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -47,6 +47,7 @@ Press the reset button at the back of the calculator to return to the firmware.
 
 Use the version table below to select a method. A few things to note:
   + The version table below is *inclusive*. For example, "from 16.3.0 to 18.0.0" includes 16.3.0, 18.0.0, and all versions in between.
+  + Version 16.4.3 does not follow this rule.
 
 <table>
   <colgroup>
@@ -63,6 +64,10 @@ Use the version table below to select a method. A few things to note:
     <tr>
       <td style="text-align: center; font-weight: bold;">18.2.3</td>
       <td style="text-align: center; font-weight: bold;"><a href="downgrade-18-2-0">Downgrade to 18.2.0</a></td>
+    </tr>
+    <tr>
+      <td style="text-align: center; font-weight: bold;">16.4.3</td>
+      <td style="text-align: center; font-weight: bold;"><a href="downgrade-18-2-0">Upgrade to 18.2.0</a></td>
     </tr>
     <tr>
       <td style="text-align: center; font-weight: bold;">16.3.0-18.2.0</td>


### PR DESCRIPTION
Some calculators are shipping with Epsilon 16.4.3 which does not follow the rule of "Everything from version 16.3.0 to 18.2.0 is compatible".
To avoid confusion, I simply added a note and a table entry (linking to the guide to upgrade to 18.2.0) for this version.
