### PR TITLE
Stop people from software-locking their Numworks

### DIFF
--- a/_pages/en_US/uninstall-phi.txt
+++ b/_pages/en_US/uninstall-phi.txt
@@ -1,7 +1,6 @@
 ---
-title: "Unistall phi"
+title: "Uninstall phi"
 ---
 
 If you have installed the Phi bootloader, and want to get rid of it to get back to
-stock Epsilon 17, you can launch the hwloader (hold 6 while pressing reset), go on
-Numworks' website and do the recovery procedure.
+stock Epsilon 18, extract the external binary [by using Section I](https://guide.getomega.dev/downgrade-18-2-0#section-i---extracting-the-external-binary) and flash the external.bin then internal.bin using [WebDFU for Numworks](https://ti-planet.github.io/webdfu_numworks/)


### PR DESCRIPTION
**Description**

While uninstalling phi, instead of redirecting people to the Numworks site to do recovery (basically software-locking their calculator) we just flash internal and external from 18-2-0.dfu.
