### PR TITLE
Remove "Power Off your device"

### DIFF
--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -31,9 +31,8 @@ If you have a N0100, STOP - your calculator is already unlocked! Continue from [
 
 #### Section III - Flash lock check
 
-1. Power off your calculator
-2. Press the "6" key
-3. While pressing the "6" key, press the reset button at the back of the device.
+1. Press the "6" key
+2. While pressing the "6" key, press the reset button at the back of the device.
 
 If you see a screen like this one, you can proceed :
 ![Epsilon 16 bootloader](images/screenshots/e16bl.png)


### PR DESCRIPTION
**Description**

The calculator doesn't need to be in sleep mode and can only be powered off if the reset button is pressed
<!--What does this pull request do? Why is it needed?-->
