### PR TITLE
Add instructions to bypass N0100 installer bug

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -44,6 +44,6 @@ If you don't want to deeply modify your calculator, [there are still a few thing
 
 | Calculator Model | What to do                                                                                      |
 |------------------|-------------------------------------------------------------------------------------------------|
-| N0100            | [Your calculator is already unlocked. Choose a Custom OS](/docs/cfw/choose-a-cfw)                     |
+| N0100            | [Your calculator is already unlocked, but some extra steps may be required](/docs/n0100-extra-steps)                     |
 | N0110            | [Check if your calculator is locked](/docs/unlock/n0110-is-locked)                               |
 | N0115 - N0120    | [You can't install a Custom OS on it. But there are still a few things you can do](/docs/unlock/what-to-do-locked) |

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -44,6 +44,6 @@ If you don't want to deeply modify your calculator, [there are still a few thing
 
 | Calculator Model | What to do                                                                                      |
 |------------------|-------------------------------------------------------------------------------------------------|
-| N0100            | [Your calculator is already unlocked, but some extra steps may be required](/docs/n0100-extra-steps)                     |
+| N0100            | [Your calculator is already unlocked, but some extra steps may be required](/docs/n0100-extra-steps) |
 | N0110            | [Check if your calculator is locked](/docs/unlock/n0110-is-locked)                               |
 | N0115 - N0120    | [You can't install a Custom OS on it. But there are still a few things you can do](/docs/unlock/what-to-do-locked) |

--- a/docs/n0100-extra-steps.md
+++ b/docs/n0100-extra-steps.md
@@ -1,0 +1,37 @@
+---
+title: "Some extra steps ? (N0100)"
+sidebar_position: 1
+pagination_next: cfw/choose-a-cfw
+pagination_prev: intro
+---
+
+### Why ?
+
+The N0100 is not locked, but, since Epsilon 19, a bug is preventing the installation of some Custom OS with the usual methods.
+
+It all depends on the version of Epsilon installed on the calculator.
+
+### If you have Epsilon 19 or later
+
+There will be some extra steps requires, it will not be long:
+
+We are simply going to install Upsilon from a binary file.
+
+#### Prerequisites
+
+The Upsilon binary file, downloadable on [Upsilon website](https://getupsilon.web.app/), at the bottom of the page.
+
+1. Open the [N0100 WebDFU](https://ti-planet.github.io/webdfu_numworks/n0100/).
+2. Connect the calculator in recovery mode by plugging it to your device and pressing RESET.
+3. Select the Upsilon binary file you just downloaded.
+4. Click on "Flash". Wait until the end of the loading.
+5. Unplug your calculator and press RESET.
+6. Your calculator now runs Upsilon.
+
+:::info
+You now have Upsilon on your calculator, but if you wanted another Custom OS or a different config, continue to the next page.
+:::
+
+### If you have Epsilon 18 or before
+
+No extra step is required, you can continue.

--- a/docs/n0100-extra-steps.md
+++ b/docs/n0100-extra-steps.md
@@ -29,7 +29,9 @@ The Upsilon binary file, downloadable on [Upsilon website](https://getupsilon.we
 6. Your calculator now runs Upsilon.
 
 :::info
+
 You now have Upsilon on your calculator, but if you wanted another Custom OS or a different config, continue to the next page.
+
 :::
 
 ### If you have Epsilon 18 or before

--- a/i18n/fr/docusaurus-plugin-content-docs/current/intro.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/intro.md
@@ -42,6 +42,6 @@ Si vous ne voulez pas profondément modifier votre calculatrice, [il y a toujour
 
 | Modèle de calculatrice | Que faut-il faire ? |
 |------------------|----------------------------------------------------------------|
-| N0100            | [Votre calculatrice est déja dévérouillée, choisisez un OS Custom](/docs/cfw/choose-a-cfw) |
+| N0100            | [Votre calculatrice est déja dévérouillée, mais quelques étapes supplémentaires pourraient être nécessaires](/docs/n0100-extra-steps) |
 | N0110            | [Vérifiez si votre calculatrice est verrouillée](/docs/unlock/n0110-is-locked) |
 | N0115 - N0120    | [Vous ne pouvez pas installer d'OS Custom dessus. Mais il y a toujours certaines choses que vous pouvez faire.](/docs/unlock/what-to-do-locked) |

--- a/i18n/fr/docusaurus-plugin-content-docs/current/n0100-extra-steps.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/n0100-extra-steps.md
@@ -29,7 +29,9 @@ Le fichier binaire d'Upsilon, téléchargeable sur [le site d'Upsilon](https://g
 6. La calculatrice est maintenant sous Upsilon.
 
 :::info
+
 Vous avez maintenant Upsilon sur votre calculatrice, mais si jamais vous souhaitez un autre OS Custom ou une configuration différente, continuez vers la page suivante.
+
 :::
 
 ### Si vous avec Epsilon 18 ou moins

--- a/i18n/fr/docusaurus-plugin-content-docs/current/n0100-extra-steps.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/n0100-extra-steps.md
@@ -21,10 +21,10 @@ Nous allons simplement installer Upsilon depuis un fichier binaire.
 
 Le fichier binaire d'Upsilon, téléchargeable sur [le site d'Upsilon](https://getupsilon.web.app/), en bas de la page.
 
-1: Ouvrir le [WebDFU N0100](https://ti-planet.github.io/webdfu_numworks/n0100/)
-2: Connecter la calculatrice en mode Recovery en la branchant à votre appareil puis en appuyant sur RESET.
-3. Sélectionner le fichier binaire d'Upsilon que vous avez téléchargé
-4. Cliquer sur "Flash". Attendre la fin du chargement
+1. Ouvrir le [WebDFU N0100](https://ti-planet.github.io/webdfu_numworks/n0100/).
+2. Connecter la calculatrice en mode Recovery en la branchant à votre appareil puis en appuyant sur RESET.
+3. Sélectionner le fichier binaire d'Upsilon que vous avez téléchargé.
+4. Cliquer sur "Flash". Attendre la fin du chargement.
 5. Débrancher la calculatrice puis appuyer sur RESET.
 6. La calculatrice est maintenant sous Upsilon.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/n0100-extra-steps.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/n0100-extra-steps.md
@@ -11,13 +11,13 @@ La N0100 n'est pas bloquée, cependant, depuis Epsilon 19, un bug empêche d'ins
 
 Tout dépend de la version d'Epsilon installée sur la calculatrice.
 
-### Si vous avez Epsilon 19 ou plus:
+### Si vous avez Epsilon 19 ou plus
 
 Il va y avoir quelques étapes supplémentaires, cela ne sera pas long:
 
 Nous allons simplement installer Upsilon depuis un fichier binaire.
 
-#### Préréquis:
+#### Préréquis
 
 Le fichier binaire d'Upsilon, téléchargeable sur [le site d'Upsilon](https://getupsilon.web.app/), en bas de la page.
 
@@ -32,6 +32,6 @@ Le fichier binaire d'Upsilon, téléchargeable sur [le site d'Upsilon](https://g
 Vous avez maintenant Upsilon sur votre calculatrice, mais si jamais vous souhaitez un autre OS Custom ou une configuration différente, continuez vers la page suivante.
 :::
 
-### Si vous avec Epsilon 18 ou moins:
+### Si vous avec Epsilon 18 ou moins
 
 Aucune étape supplémentaire nécessaire, vous pouvez continuer.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/n0100-extra-steps.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/n0100-extra-steps.md
@@ -32,6 +32,6 @@ Le fichier binaire d'Upsilon, téléchargeable sur [le site d'Upsilon](https://g
 Vous avez maintenant Upsilon sur votre calculatrice, mais si jamais vous souhaitez un autre OS Custom ou une configuration différente, continuez vers la page suivante.
 :::
 
-### Si vous avec Epsilon 18 ou moins
+### Si vous avec Epsilon 18 ou moins:
 
 Aucune étape supplémentaire nécessaire, vous pouvez continuer.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/n0100-extra-steps.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/n0100-extra-steps.md
@@ -1,0 +1,37 @@
+---
+title: "Quelques étapes supplémentaires ? (N0100)"
+sidebar_position: 1
+pagination_next: cfw/choose-a-cfw
+pagination_prev: intro
+---
+
+### Pourquoi ?
+
+La N0100 n'est pas bloquée, cependant, depuis Epsilon 19, un bug empêche d'installer certains OS Custom avec les méthodes habituelles.
+
+Tout dépend de la version d'Epsilon installée sur la calculatrice.
+
+### Si vous avez Epsilon 19 ou plus:
+
+Il va y avoir quelques étapes supplémentaires, cela ne sera pas long:
+
+Nous allons simplement installer Upsilon depuis un fichier binaire.
+
+#### Préréquis:
+
+Le fichier binaire d'Upsilon, téléchargeable sur [le site d'Upsilon](https://getupsilon.web.app/), en bas de la page.
+
+1: Ouvrir le [WebDFU n0100](https://ti-planet.github.io/webdfu_numworks/n0100/)
+2: Connecter la calculatrice en mode Recovery en la branchant à votre appareil puis en appuyant sur RESET.
+3. Sélectionner le fichier binaire d'Upsilon que vous avez téléchargé
+4. Cliquer sur "Flash". Attendre la fin du chargement
+5. Débrancher la calculatrice puis appuyer sur RESET.
+6. La calculatrice est maintenant sous Upsilon.
+
+:::info
+Vous avez maintenant Upsilon sur votre calculatrice, mais si jamais vous souhaitez un autre OS Custom ou une configuration différente, continuez vers la page suivante.
+:::
+
+### Si vous avec Epsilon 18 ou moins
+
+Aucune étape supplémentaire nécessaire, vous pouvez continuer.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/n0100-extra-steps.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/n0100-extra-steps.md
@@ -21,7 +21,7 @@ Nous allons simplement installer Upsilon depuis un fichier binaire.
 
 Le fichier binaire d'Upsilon, téléchargeable sur [le site d'Upsilon](https://getupsilon.web.app/), en bas de la page.
 
-1: Ouvrir le [WebDFU n0100](https://ti-planet.github.io/webdfu_numworks/n0100/)
+1: Ouvrir le [WebDFU N0100](https://ti-planet.github.io/webdfu_numworks/n0100/)
 2: Connecter la calculatrice en mode Recovery en la branchant à votre appareil puis en appuyant sur RESET.
 3. Sélectionner le fichier binaire d'Upsilon que vous avez téléchargé
 4. Cliquer sur "Flash". Attendre la fin du chargement


### PR DESCRIPTION
When N0100 calculators run Epsilon 19 or later, a bug prevents Omega and Upsilon installers to actually install the OS, for Upsilon, it looks like it thinks it's an N0110, even in recovery mode.
The instructions ask to install an Upsilon binary file with WebDFU
I would have preferred an Omega file but the website downloads does not work